### PR TITLE
ci: allow manual workflow_dispatch trigger for backend CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'backend/**'
       - '.github/workflows/backend-ci.yml'
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
This PR adds the `workflow_dispatch` trigger to the backend CI workflow, allowing it to be manually triggered from the GitHub Actions UI. No changes to existing push/pull_request triggers.

Rorschach says: Now you can smash that "Run workflow" button whenever the mood strikes, without waiting for a push or PR event. CI at your command.