### PR TITLE
Add robust backend logging (file/syslog, testable, documented)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Captioner
 
 Captioner is a private web application for viewing and captioning photographs. It features a React frontend and a FastAPI backend, storing images on the local filesystem and captions in a SQLite database. Designed for simplicity and extensibility, Captioner makes managing your photo collection and their captions straightforward, with a clean, organized codebase ready for future enhancements.
+
+## Backend Logging
+
+The backend logs all major events—including app startup, image scans, and file monitoring—to both stdout and a rotating log file (`logs/server.log` by default). This makes debugging and monitoring easy.
+
+- **Log file location:** By default, logs are written to `backend/logs/server.log`. To change this, set the `LOG_DIR` environment variable before starting the backend.
+- **Log level:** Set the `LOG_LEVEL` environment variable to `DEBUG`, `INFO`, etc. (default: `INFO`).
+- **Syslog:** To enable syslog logging, set `SYSLOG_ENABLE=1` in the environment.
+
+Example:
+```bash
+LOG_LEVEL=DEBUG LOG_DIR=/tmp/logs SYSLOG_ENABLE=1 venv/bin/uvicorn app.main:app
+```
+
+All image discovery (startup scan, folder monitoring) and errors are logged. See the log file for details if something goes sideways.

--- a/backend/app/image_utils.py
+++ b/backend/app/image_utils.py
@@ -5,6 +5,8 @@ from app.crud import get_photo_by_hash, add_photo
 from app.models import Photo
 
 import threading
+import logging
+logger = logging.getLogger(__name__)
 try:
     from watchdog.observers import Observer
     from watchdog.events import FileSystemEventHandler
@@ -103,8 +105,9 @@ class ImageCreatedHandler(FileSystemEventHandler):
             db = self.db_factory()
             if not get_photo_by_hash(db, sha256):
                 add_photo(db, sha256, path.name, caption=None)
+            logger.info(f"Image created: {path} (sha256={sha256})")
         except Exception as e:
-            print(f"Exception while handling {path}: {e}")
+            logger.error(f"Exception while handling {path}: {e}")
     def on_modified(self, event):
 
         if event.is_directory:
@@ -122,8 +125,9 @@ class ImageCreatedHandler(FileSystemEventHandler):
             db = self.db_factory()
             if not get_photo_by_hash(db, sha256):
                 add_photo(db, sha256, path.name, caption=None)
+            logger.info(f"Image created: {path} (sha256={sha256})")
         except Exception as e:
-            print(f"Exception while handling {path}: {e}")
+            logger.error(f"Exception while handling {path}: {e}")
     def on_moved(self, event):
         pass
 
@@ -145,8 +149,9 @@ class ImageCreatedHandler(FileSystemEventHandler):
             db = self.db_factory()
             if not get_photo_by_hash(db, sha256):
                 add_photo(db, sha256, path.name, caption=None)
+            logger.info(f"Image created: {path} (sha256={sha256})")
         except Exception as e:
-            print(f"Exception while handling {path}: {e}")
+            logger.error(f"Exception while handling {path}: {e}")
 
 def start_watching_photos_folder(photos_dir: Path, db_factory):
     global _photos_observer
@@ -189,6 +194,9 @@ def scan_photos_folder_on_startup(photos_dir: Path, db):  # db should come from 
             continue
         add_photo(db, sha256, file.name, caption=None)
         db.commit()
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.info(f"Image created: {file} (sha256={sha256})")
 
 def save_image_file(photos_dir: Path, sha256: str, ext: str, data: bytes) -> Path:
     photos_dir.mkdir(parents=True, exist_ok=True)

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,0 +1,56 @@
+import logging
+import logging.handlers
+import os
+from pathlib import Path
+
+def setup_logging(log_dir=None, syslog_enable=False):
+    """
+    Configure logging for the backend. Logs to stdout and a rotating file.
+    Optionally logs to syslog if syslog_enable is True.
+    """
+    # Allow override via environment variable for testability
+    env_log_dir = os.environ.get("LOG_DIR")
+    if env_log_dir:
+        log_dir = Path(env_log_dir)
+    else:
+        log_dir = log_dir or Path(__file__).parent.parent / "logs"
+    log_dir = Path(log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "server.log"
+
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    formatter = logging.Formatter(
+        fmt="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+
+    # Remove ALL handlers (not just default) so re-calling works in tests
+    while root_logger.handlers:
+        root_logger.removeHandler(root_logger.handlers[0])
+
+    # StreamHandler (stdout)
+    sh = logging.StreamHandler()
+    sh.setFormatter(formatter)
+    root_logger.addHandler(sh)
+
+    # RotatingFileHandler
+    fh = logging.handlers.RotatingFileHandler(
+        log_file, maxBytes=5*1024*1024, backupCount=3, encoding="utf-8"
+    )
+    fh.setFormatter(formatter)
+    root_logger.addHandler(fh)
+
+    # Syslog (optional)
+    if syslog_enable or os.environ.get("SYSLOG_ENABLE", "0") == "1":
+        try:
+            syslog_address = "/dev/log" if os.name != "nt" else ("localhost", 514)
+            syslog_handler = logging.handlers.SysLogHandler(address=syslog_address)
+            syslog_handler.setFormatter(formatter)
+            root_logger.addHandler(syslog_handler)
+        except Exception as e:
+            root_logger.warning(f"Syslog handler could not be attached: {e}")
+
+    root_logger.info(f"Logging initialized. Level: {log_level}, Log file: {log_file}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,9 @@
 import sys
+import logging
+from app.logging_config import setup_logging
+
+# Initialize logging before anything else
+setup_logging()
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
@@ -45,14 +50,17 @@ def create_app(photos_dir=None):
             stop_watching_photos_folder()
             db_gen.close()
 
+    logger = logging.getLogger("app.main")
     app = FastAPI(lifespan=lifespan)
     app.state.thumbnail_cache = thumbnail_cache
+    logger.info("FastAPI app instantiated.")
 
     # Set the photos_dir on app.state (for both prod and test)
     if photos_dir is None:
         app.state.photos_dir = Path(__file__).parent.parent / "photos"
     else:
         app.state.photos_dir = photos_dir
+    logger.info(f"Photos directory set to: {app.state.photos_dir}")
 
     app.add_middleware(
         CORSMiddleware,

--- a/backend/tests/test_logging_backend.py
+++ b/backend/tests/test_logging_backend.py
@@ -1,0 +1,64 @@
+import os
+import re
+import tempfile
+import pytest
+from pathlib import Path
+from fastapi.testclient import TestClient
+from app.main import create_app
+from app.db import Base
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def test_logging_image_scan(tmp_path, monkeypatch):
+    """
+    Ensure that image scan logs to the log file when a new image is found.
+    """
+    # Setup temp log dir
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("SYSLOG_ENABLE", "0")
+    monkeypatch.setenv("LOG_DIR", str(log_dir))
+
+    # Setup temp photos dir
+    photos_dir = tmp_path / "photos"
+    photos_dir.mkdir()
+    # Create a fake image file
+    fake_image = b"logscancontent"
+    filename = "logscan.jpeg"
+    test_hash = __import__('hashlib').sha256(fake_image).hexdigest()
+    hashed_filename = f"{test_hash}.jpeg"
+    file_path = photos_dir / hashed_filename
+    file_path.write_bytes(fake_image)
+
+    # Setup temp DB
+    db_fd, db_path = tempfile.mkstemp()
+    engine = create_engine(f"sqlite:///{db_path}")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    # Re-initialize logging so it uses the temp log dir
+    from app.logging_config import setup_logging
+    setup_logging()
+
+    # Reload image_utils so its logger attaches to the new handlers
+    import importlib
+    from app import image_utils
+    importlib.reload(image_utils)
+
+    # Create app with temp dirs
+    app = create_app(photos_dir=photos_dir)
+    app.state.db_sessionmaker = TestingSessionLocal
+    with TestClient(app):
+        pass  # triggers scan on startup
+
+    # Check log file for image created log
+    log_file = log_dir / "server.log"
+    assert log_file.exists(), "Log file was not created."
+    log_content = log_file.read_text()
+    pattern = rf"Image created: {re.escape(str(file_path))} \(sha256={test_hash}\)"
+    assert re.search(pattern, log_content), f"Expected log line not found. Log content:\n{log_content}"
+
+    os.close(db_fd)
+    os.unlink(db_path)

--- a/backend/tests/test_rescan_endpoint.py
+++ b/backend/tests/test_rescan_endpoint.py
@@ -12,8 +12,9 @@ from sqlalchemy.orm import sessionmaker
 
 def test_rescan_endpoint_adds_new_image(test_app, temp_photos_dir):
     # Place a new image in the folder
+    import uuid
     img_path = temp_photos_dir / "test1.jpg"
-    img_path.write_bytes(b"fakeimagedata1")
+    img_path.write_bytes(b"fakeimagedata1_" + uuid.uuid4().hex.encode())
     # Call rescan endpoint
     resp = test_app.post("/rescan")
     assert resp.status_code == 200
@@ -23,8 +24,9 @@ def test_rescan_endpoint_adds_new_image(test_app, temp_photos_dir):
     assert any(p["filename"] == "test1.jpg" for p in photos)
 
 def test_rescan_endpoint_idempotent(test_app, temp_photos_dir):
+    import uuid
     img_path = temp_photos_dir / "test2.png"
-    img_path.write_bytes(b"fakeimagedata2")
+    img_path.write_bytes(b"fakeimagedata2_" + uuid.uuid4().hex.encode())
     # First rescan
     resp1 = test_app.post("/rescan")
     assert resp1.status_code == 200


### PR DESCRIPTION
This PR adds comprehensive, configurable logging to the backend:
- Logs all major events (startup, image scan, folder monitoring, errors) to both stdout and a rotating file (`logs/server.log` by default).
- Supports log location and level via `LOG_DIR` and `LOG_LEVEL` env vars; syslog support via `SYSLOG_ENABLE`.
- All image discovery (startup scan, runtime monitoring) is now logged at INFO level.
- Includes a pytest that verifies log output for image scan events.
- README updated with logging instructions.

All tests pass. This closes #6.

Rorschach handled the implementation and test coverage. Please review, squash, and merge if satisfied.