### PR TITLE
Remove manual test cleanup; rely on pytest isolation (fixes #4)

### DIFF
--- a/backend/tests/test_patch_photo_caption.py
+++ b/backend/tests/test_patch_photo_caption.py
@@ -32,14 +32,3 @@ def test_patch_photo_caption(test_app, temp_photos_dir):
     assert resp4.status_code == 404
     data4 = resp4.json()
     assert set(data4.keys()) == {"detail"}
-    # Cleanup
-    if file_path.exists():
-        file_path.unlink()
-    # ORM-based cleanup (optional, usually not needed with test isolation)
-    SessionLocal = test_app.app.state.db_sessionmaker
-    with SessionLocal() as session:
-        session.execute(
-            text("DELETE FROM photos WHERE hash=:hash AND filename=:filename"),
-            {"hash": data["hash"], "filename": filename}
-        )
-        session.commit()

--- a/backend/tests/test_upload_photo.py
+++ b/backend/tests/test_upload_photo.py
@@ -34,9 +34,3 @@ def test_upload_photo(test_app, temp_photos_dir):
         assert row[0] == filename
         assert row[1] == data["hash"]
         assert row[2] is None
-        # Cleanup
-        session.execute(
-            text("DELETE FROM photos WHERE hash=:hash AND filename=:filename"),
-            {"hash": data["hash"], "filename": filename}
-        )
-        session.commit()


### PR DESCRIPTION
This PR removes all manual file and DB cleanup from backend tests, relying on pytest's tmp_path isolation for robust cleanup—even after test failures or crashes. Also deletes the demonstration crash/cleanup test. All tests pass locally. Fixes #4.